### PR TITLE
Remove unnecessary 'require'

### DIFF
--- a/modules/client/head/index.js
+++ b/modules/client/head/index.js
@@ -18,7 +18,6 @@ exports.Modal = require('./modal');
 exports.fontTest = require('./fontTest');
 exports.resizeOnload = require('./resizeOnload');
 require('./layout');
-require('./sidebar');
 require('./navigationArrows');
 require('./hover');
 require('./trackLinks');


### PR DESCRIPTION
When I use the latest commit(0c9a4aa65d11e24fb7e5e3e4d43279ee93f5bd61) and execute "./edit", not found error would be occurred because 'sidebar' is no longer exist(move to jsengine).
This patch is for that.